### PR TITLE
Show progress bar during transactions and link activity logs to Etherscan

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,12 @@
 
 /* Extra tweaks */
 :root { color-scheme: dark; }
+
+@keyframes progressBar {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.progress-bar {
+  animation: progressBar 1.5s linear infinite;
+}


### PR DESCRIPTION
## Summary
- Replace "sending transaction" text with an animated progress bar while awaiting lottery results.
- Track transaction hashes in activity log and render each entry as a Sepolia Etherscan link.
- Add CSS animation for progress bar.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1a46a9870832fa6cbf8ecdeef3b2f