### PR TITLE
Slow drawing progress animation and text placement

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -428,11 +428,8 @@ export default function App() {
               </AnimatePresence>
               {loading && wonState === null ? (
                 <div className="relative w-full bg-zinc-700 rounded-full h-6 overflow-hidden">
-                  <div className="progress-bar bg-indigo-400 h-full w-1/2" />
-                  <div className="absolute inset-0 flex items-center">
-                    <div className="marquee whitespace-nowrap text-xs font-semibold text-zinc-100 w-full text-center">
-                      Drawing in progress...
-                    </div>
+                  <div className="progress-bar bg-indigo-400 h-full w-full flex items-center justify-center">
+                    <span className="text-xs font-semibold text-indigo-900">Drawing in progress...</span>
                   </div>
                 </div>
               ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -11,14 +11,5 @@
 }
 
 .progress-bar {
-  animation: progressBar 1.5s linear infinite;
-}
-
-@keyframes marquee {
-  0% { transform: translateX(100%); }
-  100% { transform: translateX(-100%); }
-}
-
-.marquee {
-  animation: marquee 2s linear infinite;
+  animation: progressBar 3s linear infinite;
 }


### PR DESCRIPTION
## Summary
- Slow the progress bar animation to run more gently
- Display "Drawing in progress..." inside the moving bar with indigo text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1afcbcb30832fbc70674c18e41c8d