### PR TITLE
Add WalletConnect integration and unify status messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ethers": "^6.13.2",
-    "framer-motion": "^11.3.31"
+    "framer-motion": "^11.3.31",
+    "@walletconnect/web3-provider": "^1.8.0",
+    "web3modal": "^1.9.12"
   },
   "devDependencies": {
     "vite": "^5.3.4",


### PR DESCRIPTION
## Summary
- integrate WalletConnect via Web3Modal for MetaMask and other wallets
- show user action comments in orange StatusMessage matching win/lose style
- handle user-rejected transactions consistently

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b6940a6c832f93424553917bf01f