### PR TITLE
Show connect wallet message when wallet is disconnected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -463,7 +463,15 @@ export default function App() {
                       ? "bg-zinc-700 cursor-not-allowed"
                       : "bg-amber-500 hover:bg-amber-400 text-black"
                   }`}
-                >{canPlay ? "PLAY" : "Wait next block"}</button>
+                >
+                  {
+                    !account
+                      ? "Connect wallet to play"
+                      : canPlay
+                        ? "PLAY"
+                        : "Wait next block"
+                  }
+                </button>
               </div>
               <div className="text-xs text-zinc-400 mt-1">Any number. Adds entropy, doesn’t change odds.</div>
             </div>


### PR DESCRIPTION
## Summary
- display "Connect wallet to play" instead of "Wait next block" when the wallet is not connected

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1bf9ced38832fb9765f9d056b4bcf