### PR TITLE
fix: refresh play availability after each block

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -271,9 +271,11 @@ export default function App() {
 
     loadUser();
     const iv = setInterval(loadUser, 5000);
+    provider.on("block", loadUser);
     return () => {
       mounted = false;
       clearInterval(iv);
+      provider.off("block", loadUser);
     };
   }, [contract, provider, account]);
 


### PR DESCRIPTION
## Summary
- refresh pending prize, last play block, and current block on every new block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1e5eda208832f9e2be5c67b33694c