### PR TITLE
Enable manual refresh via Wait button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -431,6 +431,20 @@ export default function App() {
     }
   }
 
+  async function refreshBlocks() {
+    if (!provider || !contract || !account) return;
+    try {
+      const [blk, next] = await Promise.all([
+        provider.getBlockNumber(),
+        contract.nextAllowedBlock(account),
+      ]);
+      setCurrentBlock(BigInt(blk));
+      setNextAllowedBlock(next);
+    } catch (e) {
+      console.error("Error refreshing block data:", e);
+    }
+  }
+
   async function doClaim() {
     if (!contract) return;
     try {
@@ -632,15 +646,21 @@ export default function App() {
                   onChange={(e) => setSalt(e.target.value.replace(/\D/g, ""))}
                 />
                 <button
-                  disabled={!account || loading || !canPlay}
-                  onClick={doPlay}
+                  disabled={!account || loading}
+                  onClick={canPlay ? doPlay : refreshBlocks}
                   className={`px-6 py-3 rounded-2xl font-bold text-lg shadow transition ${
-                    !account || loading || !canPlay
+                    !account || loading
                       ? "bg-zinc-700 cursor-not-allowed"
-                      : "bg-amber-500 hover:bg-amber-400 text-black"
+                      : canPlay
+                      ? "bg-amber-500 hover:bg-amber-400 text-black"
+                      : "bg-zinc-700 hover:bg-zinc-600 cursor-pointer"
                   }`}
                 >
-                  {!account ? "Connect wallet to play" : canPlay ? "Play" : `Wait (block ${nextAllowedBlock.toString()})`}
+                  {!account
+                    ? "Connect wallet to play"
+                    : canPlay
+                    ? "Play"
+                    : `Wait (block ${nextAllowedBlock.toString()})`}
                 </button>
               </div>
               <div className="text-xs text-zinc-400 mt-1">Any number. Adds entropy, doesn't change odds.</div>


### PR DESCRIPTION
## Summary
- Allow "Wait" button to trigger manual refresh when a round can't be played
- Added helper to reload current and next allowed block numbers

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a1fdc36000832f9c84e2b77fe919eb