### PR TITLE
Limit recent results to four entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,7 +246,7 @@ export default function App() {
         setRecentResults(
           events
             .filter((ev) => ev.args)
-            .slice(-5)
+            .slice(-4)
             .reverse()
             .map((ev) => ({
               player: ev.args.player,


### PR DESCRIPTION
## Summary
- restrict recent winners/losers list to last four results by adjusting slice call

## Testing
- `npm test` *(fails: missing script: test)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a22a7194fc832fb516278ae8d44f0f